### PR TITLE
Windows環境でもパスが解析できるように変更

### DIFF
--- a/src/services/AnalysisService.ts
+++ b/src/services/AnalysisService.ts
@@ -258,8 +258,8 @@ export class AnalysisService {
    */
   async updateFeatureCache(featureFormat: string): Promise<UpdateAnalysisResponse> {
     try {
-      // 入力ディレクトリのテストケースファイルを検索
-      const inputFiles = glob.sync(path.join(this.inputDir, '*.txt'));
+      // 入力ディレクトリのテストケースファイルを検索（クロスプラットフォーム対応）
+      const inputFiles = glob.sync('*.txt', { cwd: this.inputDir, absolute: true });
 
       // 特徴量を抽出して保存
       let featureCount = 0;


### PR DESCRIPTION
https://github.com/yunix-kyopro/pahcer-studio/issues/3
こちらのissueへの対応。
windows環境ではパス区切りがバックスラッシュなので、
```
      const inputFiles = glob.sync(path.join(this.inputDir, '*.txt'));
```
このような指定の方法だと、
```
'C:\\tools\\in\\*.txt'
```
のような文字列がglob.syncに渡されることになる。globはUNIX系のファイルシステムが前提になっているので、これだとエラーが出てしまう(らしい)

そこで、
```
glob.sync('*.txt', { cwd: this.inputDir, absolute: true })
```
このような書き方をすると、globの中でthis.inputDirにchange directoryしてから"*.txt"を探すのでエラーが出なくなる(はず)。